### PR TITLE
Make APIs public

### DIFF
--- a/cmd/ww/file.go
+++ b/cmd/ww/file.go
@@ -15,10 +15,10 @@ const (
 	msgChunkSize = 32 << 10
 )
 
-type header struct {
-	Name string `json:"name",omitempty`
-	Size int    `json:"size",omitempty`
-	Type string `json:"type",omitempty`
+type Header struct {
+	Name string `json:"name,omitempty"`
+	Size int    `json:"size,omitempty"`
+	Type string `json:"type,omitempty"`
 }
 
 func receive(args ...string) {
@@ -51,7 +51,7 @@ func receive(args ...string) {
 		if err != nil {
 			fatalf("could not read file header: %v", err)
 		}
-		var h header
+		var h Header
 		err = json.Unmarshal(buf[:n], &h)
 		if err != nil {
 			fatalf("could not decode file header: %v", err)
@@ -102,7 +102,7 @@ func send(args ...string) {
 		if err != nil {
 			fatalf("could not stat file %s: %v", filename, err)
 		}
-		h, err := json.Marshal(header{
+		h, err := json.Marshal(Header{
 			Name: filepath.Base(filepath.Clean(filename)),
 			Size: int(info.Size()),
 		})

--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -22,7 +22,7 @@ var subcmds = map[string]func(args ...string){
 	"send":    send,
 	"receive": receive,
 	"pipe":    pipe,
-	"server":  server,
+	"server":  Server,
 }
 
 var (

--- a/cmd/ww/server.go
+++ b/cmd/ww/server.go
@@ -321,7 +321,7 @@ func relay(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func server(args ...string) {
+func Server(args ...string) {
 	rand.Seed(time.Now().UnixNano()) // for slot allocation
 
 	set := flag.NewFlagSet(args[0], flag.ExitOnError)


### PR DESCRIPTION
To support Go language standards and best practices of testing project dependencies the `Server` function and `Header` structure are marked as publicly exported.