### PR TITLE
CCLAVE-2864/fix landing page typo

### DIFF
--- a/cmd/ww/pipe.go
+++ b/cmd/ww/pipe.go
@@ -25,7 +25,7 @@ func pipe(args ...string) {
 	c := newConn(set.Arg(0), *length)
 
 	done := make(chan struct{})
-	// The recieve end of the pipe.
+	// The receive end of the pipe.
 	go func() {
 		_, err := io.CopyBuffer(os.Stdout, c, make([]byte, msgChunkSize))
 		if err != nil {

--- a/web/index.html
+++ b/web/index.html
@@ -20,7 +20,7 @@
 <div class="header">
   <img class="logo" src="logo.svg" alt="CrossClave" />
 </div>
-<p id="hint">Recieve a file with end-to-end<br />encrypted magic</p>
+<p id="hint">Receive a file with end-to-end<br />encrypted magic</p>
 <img id="receive-image" src="receive-file.png" alt="CrossClave" />
 <ul id="transfers">
   <li id="list-item">


### PR DESCRIPTION
This PR fixes two typos, one on the landing page and the other in a comment. 